### PR TITLE
Bring changes from `master` to `main`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,95 @@
+name: 'cd'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'project.clj'
+
+permissions:
+  contents: read
+  # Needed for the 'trilom/file-changes-action' action
+  pull-requests: read
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ${{ fromJSON('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu' # See 'Supported distributions' for available options
+          java-version: '11'
+
+      - name: Display (print) node and java versions
+        run:
+          node -v && java --version
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@9.5
+        with:
+          # Install just one or all simultaneously
+          # The value must indicate a particular version of the tool, or use 'latest'
+          # to always provision the latest version
+          cli: 1.11.1.1149             # Clojure CLI based on tools.deps
+          lein: 2.9.8                  # Leiningen
+          clj-kondo: 2022.05.31        # Clj-kondo
+
+      - name: Get clj-kondo version. Clj-kondo searches for opportunities of optimizations
+        run: clj-kondo --version
+
+         # # Optional step:
+         # - name: Cache clojure dependencies
+         #   uses: actions/cache@v3
+         #   with:
+         #     path: |
+         #       ~/.m2/repository
+         #       ~/.gitlibs
+         #       ~/.deps.clj
+         #     # List all files containing dependencies:
+         #     key: cljdeps-${{ hashFiles('deps.edn') }}
+         #     # key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+         #     # key: cljdeps-${{ hashFiles('project.clj') }}
+         #     # key: cljdeps-${{ hashFiles('build.boot') }}
+         #     restore-keys: cljdeps-
+
+      - name: Test if vanilla clojure code is working
+        run: clojure -e "(+ 1 1)"
+
+      - name: Display Leiningen version
+        run: lein -v
+
+      # - name: Run cljfmt formatter
+      #   run: lein cljfmt check
+
+      # - name: Run clj-kondo
+      #   run: clj-kondo --lint src
+
+      - name: lein install on this version of firebase-re-frame
+        run:
+          lein install
+
+      # - name: Run lein tests
+      #   run: lein test
+
+      - name: Deploy to Github Package Registry
+        env:
+          GITHUB_TOKEN: ${{ secrets.RE_FRAME_FIREBASE_REPOSITORY_SECRET_ACTIONS }}
+        run: |
+          mkdir -p ~/.m2
+          echo "<settings><servers><server><id>github</id><username>$(echo '$GITHUB_REPOSITORY' | awk -F / '{print $1}')</username><password>\${env.GITHUB_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
+          REPO="gh::default::https://maven.pkg.github.com/${GITHUB_REPOSITORY}"
+          mvn deploy -DaltReleaseDeploymentRepository="${REPO}" -DaltSnapshotDeploymentRepository="${REPO}"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;;; Author: David Goldfarb (deg@degel.com)
 ;;; Copyright (c) 2017-8, David Goldfarb
 
-(defproject tallyfor/re-frame-firebase "0.10.0"
+(defproject tallyfor/re-frame-firebase "0.10.1"
   :description "A re-frame wrapper around firebase"
   :url "https://github.com/deg/re-frame-firebase"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;;; Author: David Goldfarb (deg@degel.com)
 ;;; Copyright (c) 2017-8, David Goldfarb
 
-(defproject tallyfor/re-frame-firebase "0.10.1"
+(defproject tallyfor/re-frame-firebase "0.10.2"
   :description "A re-frame wrapper around firebase"
   :url "https://github.com/deg/re-frame-firebase"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;;; Author: David Goldfarb (deg@degel.com)
 ;;; Copyright (c) 2017-8, David Goldfarb
 
-(defproject tallyfor/re-frame-firebase "0.10.2"
+(defproject tallyfor/re-frame-firebase "0.10.3"
   :description "A re-frame wrapper around firebase"
   :url "https://github.com/deg/re-frame-firebase"
   :license {:name "Eclipse Public License"
@@ -13,9 +13,7 @@
                  [com.degel/iron "0.4.0"]
                  [lein-pprint             "1.3.2"]
                  [lein-cljsbuild "1.1.8"]
-                 [lein-bump-version "0.1.6"]
-                 [lein-tools-deps "0.4.5"]]
-  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+                 [lein-bump-version "0.1.6"]]
   ;; run lein install with LEIN_SNAPSHOTS_IN_RELEASE=true lein install
   :lein-tools-deps/config {:config-files [:install :user :project]}
 

--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,35 @@
                  [org.clojure/clojurescript "1.10.439"]
                  [cljsjs/firebase "7.5.0-0"] ;;"5.7.3-1"
                  [re-frame "0.10.6"]
-                 [com.degel/iron "0.4.0"]]
+                 [com.degel/iron "0.4.0"]
+                 [lein-pprint             "1.3.2"]
+                 [lein-cljsbuild "1.1.8"]
+                 [lein-bump-version "0.1.6"]
+                 [lein-tools-deps "0.4.5"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  ;; run lein install with LEIN_SNAPSHOTS_IN_RELEASE=true lein install
+  :lein-tools-deps/config {:config-files [:install :user :project]}
+
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
   :cljsbuild {:builds {}} ; prevent https://github.com/emezeske/lein-cljsbuild/issues/413
   :plugins [[lein-npm "0.6.2"]]
   :npm {:dependencies [[source-map-support "0.5.6"]]}
+  :profiles {:dev      {:dependencies [[clj-stacktrace "0.2.8"]
+                                       [binaryage/devtools "0.9.10"]
+                                       [org.clojure/tools.namespace "1.1.0"]]}}
   :source-paths ["src" "target/classes"]
+  ;; Change your environment variables (maybe editing .zshrc or .bashrc) to have:
+  ;; export LEIN_USERNAME="pdelfino"
+  ;; export LEIN_PASSWORD="your-personal-access-token-the-same-used-on-.npmrc"
+  ;; LEIN_PASSWORD should use the same Token used by .npmrc
+  ;; Also, do "LEIN_SNAPSHOTS_IN_RELEASE=true lein install" or edit your .zshrc:
+  ;; export LEIN_SNAPSHOTS_IN_RELEASE=true
+  :repositories {"releases"  {:url           "https://maven.pkg.github.com/tallyfor/*"
+                              :username      :env/LEIN_USERNAME ;; change your env
+                              :password      :env/LEIN_PASSWORD}}
+
+  :pom-addition [:distribution-management [:repository [:id "github"]
+                                           [:name "GitHub Packages"]
+                                           [:url "https://maven.pkg.github.com/tallyfor/re-frame-firebase"]]]
   :clean-targets ["out" "release"]
   :target-path "target")

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;;; Author: David Goldfarb (deg@degel.com)
 ;;; Copyright (c) 2017-8, David Goldfarb
 
-(defproject com.degel/re-frame-firebase "0.10.0"
+(defproject tallyfor/re-frame-firebase "0.10.0"
   :description "A re-frame wrapper around firebase"
   :url "https://github.com/deg/re-frame-firebase"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;;; Author: David Goldfarb (deg@degel.com)
 ;;; Copyright (c) 2017-8, David Goldfarb
 
-(defproject com.degel/re-frame-firebase "0.9.6-SNAPSHOT"
+(defproject com.degel/re-frame-firebase "0.10.0"
   :description "A re-frame wrapper around firebase"
   :url "https://github.com/deg/re-frame-firebase"
   :license {:name "Eclipse Public License"

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -389,7 +389,7 @@
 ;;; Firebase Storage, an online object store, different from the similarly named Firestore.
 
 (re-frame/reg-fx :storage/put storage/put-effect)
-;;(re-frame/reg-fx :storage/delete storage/delete-effect)
+(re-frame/reg-fx :storage/delete storage/delete-effect)
 
 
 ;;; Start library and register callbacks.

--- a/src/com/degel/re_frame_firebase/storage.cljs
+++ b/src/com/degel/re_frame_firebase/storage.cljs
@@ -39,5 +39,5 @@
   [path]
   (.delete (clj->StorageReference path)))
 
-(defn delete-effect [{:keys [path on-succes on-failure]}]
+(defn delete-effect [{:keys [path on-success on-failure]}]
   (promise-wrapper (deleter path) on-success on-failure))

--- a/src/com/degel/re_frame_firebase/storage.cljs
+++ b/src/com/degel/re_frame_firebase/storage.cljs
@@ -34,3 +34,10 @@
 
 (defn put-effect [{:keys [path data on-success on-failure]}]
   (promise-wrapper (putter path data) on-success on-failure))
+
+(defn- deleter
+  [path]
+  (.delete (clj->StorageReference path)))
+
+(defn delete-effect [{:keys [path on-succes on-failure]}]
+  (promise-wrapper (deleter path) on-success on-failure))


### PR DESCRIPTION
I am bringing the changes from `master` (which more up to date) to `main`.

After this is merged, I will:

1 - rename `master` to `old-master-do-not-develop`

2 - fix CD and CI to be using `main` (instead of `master`)

3 - make `main` the default branch on GitHub settings

Hopefully, this solves issue #10.

Thus, we will be using the current notation used by GitHub.